### PR TITLE
Client-side JS working

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 ## Blocmetrics
 
 - An analytics service for tracking and reporting website / application events
+
+Insert this snippet into your website or application:
+
+```
+blocmetrics = {};
+blocmetrics.report = function(eventName){
+  var event = {event: { eventname: eventName }};
+  var request = new XMLHttpRequest();
+  request.open("POST", "http://localhost:8080/api/events", true);
+  request.setRequestHeader('Content-Type', 'application/json');
+  request.send(JSON.stringify(event));
+};
+```

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,5 +1,6 @@
 class API::EventsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  skip_before_filter :authenticate_user!
   before_filter :set_access_control_headers
   
   def set_access_control_headers

--- a/app/views/registered_applications/show.html.erb
+++ b/app/views/registered_applications/show.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @app.name %></h1>
+<h5>@ <%= @app.url %></h4>
 
 <h3>Events</h3>
 <div class="col-md-8">


### PR DESCRIPTION
This is now up and running. Test using my Blocipedia app via Cloud 9.

- Added the JS snipped in the README.md to Blocipedia's `application.js` file
- Added the argument `onclick: "blocmetrics.report('wikiClick')"` to my `index` `link_to` code so the event records a click when a wiki link is clicked
- Updated Blocmetrics `events_controller` to skip user authentication -- I was noticing the event wouldn't record since the app was looking for a user to be logged in. Is this the right way? Feels like a security gap.
- Updated the `show` view so I could confirm what URL I was looking at...